### PR TITLE
Tcp 관련 기능들 수정

### DIFF
--- a/TcpClient.cs
+++ b/TcpClient.cs
@@ -40,7 +40,7 @@ class TcpClient
     public event ReceiveMessageHandler OnReceiveMessage;
 
     public delegate void LogDelegate(string message);
-    public event LogDelegate Log = delegate { };
+    public event LogDelegate Log;
 
     public Socket tcpSocket = null;
     private Thread connectThread = null;
@@ -141,7 +141,7 @@ class TcpClient
         }
         catch(Exception e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
         }
 
     }
@@ -180,7 +180,7 @@ class TcpClient
         }
         catch(SocketException e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
             if(e.ErrorCode == (int)SocketError.TimedOut && reconnectCount-- != 0)
             {
                 Thread.Sleep(3000);
@@ -189,7 +189,7 @@ class TcpClient
         }
         catch(Exception e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
         }
     }
     private void ReceiveMessage()
@@ -241,7 +241,7 @@ class TcpClient
         }
         catch(SocketException e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
             if(e.ErrorCode == (int)SocketError.ConnectionReset)
             {
                 InitializeClient(serverIp, port);
@@ -249,7 +249,7 @@ class TcpClient
         }
         catch(Exception e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
         }
     }
     private void InvokeMessageEvent()

--- a/TcpClient.cs
+++ b/TcpClient.cs
@@ -151,14 +151,12 @@ class TcpClient
         receiveThread?.Abort();
         invokeMessageThread?.Abort();
         tcpSocket.Close();
-        Log("Terminate");
     }
 
     private void Connect(object endPoint)
     {
         try
         {
-            Log("Try Connect");
             IPEndPoint ipEndpoint = (IPEndPoint)endPoint;
 
             IAsyncResult connectResult = tcpSocket.BeginConnect(ipEndpoint, null, null);
@@ -167,7 +165,6 @@ class TcpClient
             if(tcpSocket.Connected)
             {
                 tcpSocket.EndConnect(connectResult);
-                Log("Connect Accept");
                 receiveDataQueue.Clear();
                 receiveThread = new Thread(ReceiveMessage);
                 receiveThread.Start();
@@ -183,22 +180,16 @@ class TcpClient
         }
         catch(SocketException e)
         {
-            Log("Errror Connect A ; " + e.Message);
-
+            Log(e.Message);
             if(e.ErrorCode == (int)SocketError.TimedOut && reconnectCount-- != 0)
             {
                 Thread.Sleep(3000);
-                Log("Retry Connect");
                 InitializeClient(serverIp, port);
-            }
-            else
-            {
-                Log("No Retry Connect");
             }
         }
         catch(Exception e)
         {
-            Log("Errror Connect B ; " + e.Message);
+            Log(e.Message);
         }
     }
     private void ReceiveMessage()
@@ -207,11 +198,9 @@ class TcpClient
         {
             while(true)
             {
-                int dataLength;
-
                 byte[] dataSize = new byte[4];
                 tcpSocket.Receive(dataSize, 0, 4, SocketFlags.None);
-                dataLength = BitConverter.ToInt32(dataSize, 0);
+                int dataLength = BitConverter.ToInt32(dataSize, 0);
 
                 byte[] receivedData = new byte[dataLength];
                 int remainDataLength = dataLength;
@@ -252,7 +241,7 @@ class TcpClient
         }
         catch(SocketException e)
         {
-            Log("Receive Socket Error : " + e.Message);
+            Log(e.Message);
             if(e.ErrorCode == (int)SocketError.ConnectionReset)
             {
                 InitializeClient(serverIp, port);
@@ -260,7 +249,7 @@ class TcpClient
         }
         catch(Exception e)
         {
-            Log("Receive Other Error : " + e.Message);
+            Log(e.Message);
         }
     }
     private void InvokeMessageEvent()

--- a/TcpClient.cs
+++ b/TcpClient.cs
@@ -40,7 +40,7 @@ class TcpClient
     public event ReceiveMessageHandler OnReceiveMessage;
 
     public delegate void LogDelegate(string message);
-    public LogDelegate PrintLog = null;
+    public event LogDelegate PrintLog = null;
 
     public Socket tcpSocket = null;
     private Thread connectThread = null;
@@ -67,6 +67,7 @@ class TcpClient
 
         invokeMessageThread = new Thread(InvokeMessageEvent);
         invokeMessageThread.Start();
+
     }
     /// <summary>
     /// TCP 모듈을 초기화시켜준다.

--- a/TcpServer.cs
+++ b/TcpServer.cs
@@ -60,8 +60,12 @@ class TcpServer
     /// </usage>
     public event ReceiveMessageHandler OnReceiveMessage;
 
+    public delegate void SessionChangedEventHandler(TcpSession clientSession);
+    public event SessionChangedEventHandler OnConnectAccept = delegate { };
+    public event SessionChangedEventHandler OnTerminate = delegate { };
+
     public delegate void LogEventHandler(string message);
-    public LogEventHandler Log;
+    public event LogEventHandler Log;
 
     public List<TcpSession> sessionList;
 
@@ -186,6 +190,7 @@ class TcpServer
 
         targetSession.TerminateClient();
         sessionList.Remove(targetSession);
+        OnTerminate(targetSession);
     }
 
     private void WaitClient()
@@ -210,6 +215,7 @@ class TcpServer
 
                     TcpSession tcpSession = new TcpSession(client, ip.Address.ToString());
                     sessionList.Add(tcpSession);
+                    OnConnectAccept(tcpSession);
 
                     Thread listenThread = new Thread(new ParameterizedThreadStart(ListenMessage));
                     listenThread.Start(client);

--- a/TcpServer.cs
+++ b/TcpServer.cs
@@ -177,20 +177,24 @@ class TcpServer
     /// <param name="targetSocket">신호를 보낸 클라이언트의 소켓</param>
     public void TerminateClient(Socket targetSocket)
     {
-        TcpSession targetSession = null;
+        //TcpSession targetSession = null;
 
-        foreach(TcpSession tcpSession in sessionList)
+        //foreach(TcpSession tcpSession in sessionList)
+        //{
+        //    if(tcpSession.socket == targetSocket)
+        //    {
+        //        targetSession = tcpSession;
+        //        break;
+        //    }
+        //}
+
+        TcpSession targetSession = sessionList.Find(s => s.socket == targetSocket);
+        if(targetSession != null)
         {
-            if(tcpSession.socket == targetSocket)
-            {
-                targetSession = tcpSession;
-                break;
-            }
+            targetSession.TerminateClient();
+            sessionList.Remove(targetSession);
+            OnTerminate(targetSession);
         }
-
-        targetSession.TerminateClient();
-        sessionList.Remove(targetSession);
-        OnTerminate(targetSession);
     }
 
     private void WaitClient()

--- a/TcpServer.cs
+++ b/TcpServer.cs
@@ -255,7 +255,8 @@ class TcpServer
         {
             if(!clientSocket.Connected)
             {
-                return null;
+                Log("Receive null Disconnect");
+                throw new SocketException((int)SocketError.NotConnected);
             }
 
             int dataLength;
@@ -266,7 +267,8 @@ class TcpServer
 
             if(dataLength == 0)
             {
-                return null;
+                Log("Receive null data");
+                throw new SocketException((int)SocketError.NetworkUnreachable);
             }
 
             // 헤더 받은 후, 널 값 체크
@@ -306,12 +308,12 @@ class TcpServer
         }
         catch(SocketException e)
         {
-            Log("Receive Error : " + e.Message + "/" + e.GetType());
+            Log("Receive Error : " + e.Message);
             TerminateClient(clientSocket);
         }
         catch(Exception e)
         {
-            Log("Receive Error : " + e.Message + "/" + e.GetType());
+            Log("Receive Error : " + e.Message);
         }
 
         return null;

--- a/TcpServer.cs
+++ b/TcpServer.cs
@@ -61,8 +61,8 @@ class TcpServer
     public event ReceiveMessageHandler OnReceiveMessage;
 
     public delegate void SessionChangedEventHandler(TcpSession clientSession);
-    public event SessionChangedEventHandler OnConnectAccept = delegate { };
-    public event SessionChangedEventHandler OnTerminate = delegate { };
+    public event SessionChangedEventHandler OnConnectAccept;
+    public event SessionChangedEventHandler OnTerminate;
 
     public delegate void LogEventHandler(string message);
     public event LogEventHandler Log;
@@ -193,7 +193,7 @@ class TcpServer
         {
             targetSession.TerminateClient();
             sessionList.Remove(targetSession);
-            OnTerminate(targetSession);
+            OnTerminate?.Invoke(targetSession);
         }
     }
 
@@ -219,7 +219,7 @@ class TcpServer
 
                     TcpSession tcpSession = new TcpSession(client, ip.Address.ToString());
                     sessionList.Add(tcpSession);
-                    OnConnectAccept(tcpSession);
+                    OnConnectAccept?.Invoke(tcpSession);
 
                     Thread listenThread = new Thread(new ParameterizedThreadStart(ListenMessage));
                     listenThread.Start(client);
@@ -228,7 +228,7 @@ class TcpServer
         }
         catch(Exception e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
         }
     }
     private void ListenMessage(object socket)
@@ -250,7 +250,7 @@ class TcpServer
         }
         catch(Exception e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
         }
     }
     private ReceiveData ReceiveMessage(Socket clientSocket)
@@ -310,12 +310,12 @@ class TcpServer
         }
         catch(SocketException e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
             TerminateClient(clientSocket);
         }
         catch(Exception e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
         }
 
         return null;
@@ -358,7 +358,7 @@ class TcpServer
         }
         catch(SocketException e)
         {
-            Log(e.Message);
+            Log?.Invoke(e.Message);
             return false;
         }
     }

--- a/TcpServer.cs
+++ b/TcpServer.cs
@@ -194,15 +194,18 @@ class TcpServer
         {
             while(true)
             {
+                PrintLog("Wait : Before");
                 // 클라이언트가 Full이라면 쓰레기 Session을 탐색하여 삭제한다.
                 if(sessionList.Count >= maxClientCount)
                 {
+                    PrintLog("Wait : Max");
                     RemoveTerminatedClients();
                 }
 
                 // 탐색 이후 Session List의 갯수를 확인한다.
                 if(sessionList.Count < maxClientCount)
                 {
+                    PrintLog("Wait : Accept");
                     Socket client = tcpSocket.Accept();
                     PrintLog("Accept Client");
                     IPEndPoint ip = (IPEndPoint)client.RemoteEndPoint;
@@ -215,6 +218,8 @@ class TcpServer
                     Thread listenThread = new Thread(new ParameterizedThreadStart(ListenMessage));
                     listenThread.Start(client);
                 }
+
+                PrintLog("Wait : Result /" + sessionList.Count);
             }
         }
         catch(Exception e)
@@ -302,6 +307,7 @@ class TcpServer
         catch(Exception e)
         {
             PrintLog("Receive Error : " + e.Message);
+            TerminateClient(clientSocket);
             return null;
         }
     }

--- a/TcpServer.cs
+++ b/TcpServer.cs
@@ -78,6 +78,8 @@ class TcpServer
     private int maxClientCount = 0;
     private readonly int headerSize = 10;
     private readonly int maxPacketSize = 1024;
+    private bool isMaxConnection;
+    private IPEndPoint ipEndPoint;
 
     public TcpServer()
     {
@@ -100,9 +102,9 @@ class TcpServer
     {
         this.maxClientCount = maxClientCount;
 
-        IPEndPoint ipEndPoint = new IPEndPoint(IPAddress.Any, port);
-        tcpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        ipEndPoint = new IPEndPoint(IPAddress.Any, port);
 
+        tcpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
         tcpSocket.Bind(ipEndPoint);
         tcpSocket.Listen(10);
 
@@ -212,6 +214,12 @@ class TcpServer
                 // 탐색 이후 Session List의 갯수를 확인한다.
                 if(sessionList.Count < maxClientCount)
                 {
+                    if(isMaxConnection)
+                    {
+                        tcpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                        tcpSocket.Bind(ipEndPoint);
+                        tcpSocket.Listen(10);
+                    }
                     Socket client = tcpSocket.Accept();
                     IPEndPoint ip = (IPEndPoint)client.RemoteEndPoint;
 
@@ -223,6 +231,11 @@ class TcpServer
 
                     Thread listenThread = new Thread(new ParameterizedThreadStart(ListenMessage));
                     listenThread.Start(client);
+                }
+                else
+                {
+                    tcpSocket.Close();
+                    isMaxConnection = true;
                 }
             }
         }

--- a/TcpServer.cs
+++ b/TcpServer.cs
@@ -224,7 +224,7 @@ class TcpServer
         }
         catch(Exception e)
         {
-            Log("Wait Error : " + e.Message);
+            Log(e.Message);
         }
     }
     private void ListenMessage(object socket)
@@ -246,7 +246,7 @@ class TcpServer
         }
         catch(Exception e)
         {
-            Log("Listen Error : " + e.Message);
+            Log(e.Message);
         }
     }
     private ReceiveData ReceiveMessage(Socket clientSocket)
@@ -255,7 +255,6 @@ class TcpServer
         {
             if(!clientSocket.Connected)
             {
-                Log("Receive null Disconnect");
                 throw new SocketException((int)SocketError.NotConnected);
             }
 
@@ -267,7 +266,6 @@ class TcpServer
 
             if(dataLength == 0)
             {
-                Log("Receive null data");
                 throw new SocketException((int)SocketError.NetworkUnreachable);
             }
 
@@ -308,12 +306,12 @@ class TcpServer
         }
         catch(SocketException e)
         {
-            Log("Receive Error : " + e.Message);
+            Log(e.Message);
             TerminateClient(clientSocket);
         }
         catch(Exception e)
         {
-            Log("Receive Error : " + e.Message);
+            Log(e.Message);
         }
 
         return null;
@@ -337,9 +335,7 @@ class TcpServer
         {
             if(!IsClientConnected(tcpSession.socket))
             {
-                Log("Socket Disconnected : " + tcpSession.socket.LocalEndPoint);
                 tcpSession.TerminateClient();
-
                 terminatedSessionList.Add(tcpSession);
             }
         }
@@ -354,13 +350,11 @@ class TcpServer
     {
         try
         {
-            Log("Socket Available : " + socket.Available);
-            Log("Socket Poll : " + socket.Poll(1, SelectMode.SelectRead));
             return !(socket.Poll(1, SelectMode.SelectRead) && socket.Available == 0);
         }
         catch(SocketException e)
         {
-            Log("Check Connection Error : " + e.Message);
+            Log(e.Message);
             return false;
         }
     }


### PR DESCRIPTION
각종 기능들 추가 

- 몇가지 이름 및 간단한 알고리즘 변경
- [9352f86](https://github.com/kuhn0305/NetworkModule/commit/9352f86764cb701a065f5c32e5464d4be8f4baba) 소켓 세션이 바뀔 때에 대한 이벤트 추가 #4 
- [475e005](https://github.com/kuhn0305/NetworkModule/commit/475e0051da8353f3c285a2eb428aa417dc0ebf34) 클라이언트에서 연결 끊김으로 인한 예외 발견시 연결 재시도
- [e07eb66](https://github.com/kuhn0305/NetworkModule/commit/e07eb66d08e93dd009ee95f960f6f21996088873) 서버에서 연결 끊김으로 인한 예외 발견시 해당 세션 삭제
- [2bc46e](https://github.com/kuhn0305/NetworkModule/commit/2bc46e35c203399f1db7aea5839d8beabdf955b4) 따라서 주기적으로 삭제할 세션을 찾을 필요가 없어 해당 부분 삭제 #4 
- [c71b99](https://github.com/kuhn0305/NetworkModule/commit/c71b991e6f79712aab3848257ddbd01e1e4bcc7f) 서버에서 최대 커넥션에 도달했을시, 소켓을 닫음. 다시 여유가 생기면 새롭게 소켓을 정의. 
  > 기존의 방식에서는 서버에서 Accept하지않더라도 백로그에 들어가 있으면 클라이언트에서는 연결된 것으로 인식한다. 
  > 서버에서 아예 소켓을 닫아야 클라이언트가 연결이 안된 것으로 인식